### PR TITLE
refactor: 💡 assisted installer ursa config ip address

### DIFF
--- a/install
+++ b/install
@@ -60,7 +60,7 @@ defaultDockerFullNodeRelativePath="./docker/full-node"
 defaultDockerComposeYmlRelativePath="$defaultDockerFullNodeRelativePath/docker-compose.yml"
 defaultMinMemoryBytesRequired=8000000
 defaultMinDiskSpaceBytesRequired=10000000
-defaultUrsaConfigPath="~/.ursa/config.toml"
+defaultUrsaConfigPath="$HOME/.ursa/config.toml"
 
 # App state
 userSelectedLanguage=""
@@ -1761,7 +1761,7 @@ onLatestPreference() {
 }
 
 updateUrsaConfigIpAddress() {
-  if ! sed -i "s/addresses =*/addresses = [\"/ip4/$serverIpAddress/tcp/80\"]/" "$defaultUrsaConfigPath"; then
+  if ! sed -i "s|addresses =.*|addresses = [\"/ip4/$serverIpAddress/tcp/80\"]|" "$defaultUrsaConfigPath"; then
     showPoopMessage "${transl[on_update_ursa_config_ip_address_update_error]/_serverIpAddress_/$serverIpAddress}"
   fi
 }

--- a/install
+++ b/install
@@ -60,6 +60,7 @@ defaultDockerFullNodeRelativePath="./docker/full-node"
 defaultDockerComposeYmlRelativePath="$defaultDockerFullNodeRelativePath/docker-compose.yml"
 defaultMinMemoryBytesRequired=8000000
 defaultMinDiskSpaceBytesRequired=10000000
+defaultUrsaConfigPath="~/.ursa/config.toml"
 
 # App state
 userSelectedLanguage=""
@@ -1759,6 +1760,12 @@ onLatestPreference() {
   done
 }
 
+updateUrsaConfigIpAddress() {
+  if ! sed -i "s/addresses =*/addresses = [\"/ip4/$serverIpAddress/tcp/80\"]/" "$defaultUrsaConfigPath"; then
+    showPoopMessage "${transl[on_update_ursa_config_ip_address_update_error]/_serverIpAddress_/$serverIpAddress}"
+  fi
+}
+
 (
   # stdin to keyboard
   exec < /dev/tty;
@@ -1842,6 +1849,10 @@ onLatestPreference() {
   
   # Await a few seconds to let the user read...
   sleep 5
+
+  # The Ursa config has an ip address property
+  # which value is shared to the indexer
+  updateUrsaConfigIpAddress
 
   # Restart docker
   restartDockerStack

--- a/install
+++ b/install
@@ -1490,7 +1490,7 @@ verifyUserHasDomain() {
   # Declare detected ip address as default server ip address
   serverIpAddress=${ans:="$detectedIpAddress"}
 
-  if [[ $serverIpAddress -eq "$ERROR_IP_ADDRESS_NOT_AVAILABLE" ]]; then
+  if [[ $serverIpAddress = "$ERROR_IP_ADDRESS_NOT_AVAILABLE" ]]; then
     showErrorMessage "${transl[verify_user_has_domain_oops_embarassing]/_ERROR_IP_ADDRESS_NOT_AVAILABLE_/$ERROR_IP_ADDRESS_NOT_AVAILABLE}"
 
     exitInstaller

--- a/install
+++ b/install
@@ -60,11 +60,14 @@ defaultDockerFullNodeRelativePath="./docker/full-node"
 defaultDockerComposeYmlRelativePath="$defaultDockerFullNodeRelativePath/docker-compose.yml"
 defaultMinMemoryBytesRequired=8000000
 defaultMinDiskSpaceBytesRequired=10000000
-defaultUrsaConfigPath="$HOME/.ursa/config.toml"
+defaultUrsaConfigFilename="config.toml"
+defaultUrsaBasePath="$HOME/.ursa"
+defaultUrsaConfigPath="$defaultUrsaBasePath/$defaultUrsaConfigFilename"
 
 # App state
 userSelectedLanguage=""
 selectedUrsaPath=""
+serverIpAddress=""
 
 # Localization
 declare -a supportedLanguages=("en" "ch" "es" "pt" "fr" "it" "vi" "jp" "ko" "de" "hi" "ru")
@@ -1487,7 +1490,7 @@ verifyUserHasDomain() {
   # Declare detected ip address as default server ip address
   serverIpAddress=${ans:="$detectedIpAddress"}
 
-  if [[ $serverIpAddress = "$ERROR_IP_ADDRESS_NOT_AVAILABLE" ]]; then
+  if [[ $serverIpAddress -eq "$ERROR_IP_ADDRESS_NOT_AVAILABLE" ]]; then
     showErrorMessage "${transl[verify_user_has_domain_oops_embarassing]/_ERROR_IP_ADDRESS_NOT_AVAILABLE_/$ERROR_IP_ADDRESS_NOT_AVAILABLE}"
 
     exitInstaller
@@ -1542,9 +1545,7 @@ verifyUserHasDomain() {
     esac;
   done;
 
-  echo "$userDomainName;$emailAddress"
-
-  exit 0
+  echo "$userDomainName;$emailAddress;$serverIpAddress"
 }
 
 replaceNginxConfFileForHttp() {
@@ -1653,6 +1654,7 @@ setupSSLTLS() {
 
   userDomainName=$(echo "$trimData" | cut -d ";" -f 1)
   emailAddress=$(echo "$trimData" | cut -d ";" -f 2)
+  serverIpAddress=$(echo "$trimData" | cut -d ";" -f 3)
 
   if ! rm "$defaultDockerFullNodeRelativePath"/data/nginx/app.conf; then
     showErrorMessage "${transl[setup_ssl_tls_oops_failed_clear_nginx]} 🙏"
@@ -1761,9 +1763,26 @@ onLatestPreference() {
 }
 
 updateUrsaConfigIpAddress() {
-  if ! sed -i "s|addresses =.*|addresses = [\"/ip4/$serverIpAddress/tcp/80\"]|" "$defaultUrsaConfigPath"; then
-    showPoopMessage "${transl[on_update_ursa_config_ip_address_update_error]/_serverIpAddress_/$serverIpAddress}"
+  if [[ -f "$defaultUrsaConfigPath" ]]; then
+    if ! sed -i "s|addresses =.*|addresses = [\"/ip4/$serverIpAddress/tcp/80\"]|" "$defaultUrsaConfigPath"; then
+      if ! createUrsaInitialConfig; then
+        showPoopMessage "${transl[on_update_ursa_config_ip_address_update_error]/_serverIpAddress_/$serverIpAddress}"
+      fi
+    fi
+  else
+    if ! mkdir -p "$defaultUrsaBasePath" || ! createUrsaInitialConfig; then
+      showPoopMessage "${transl[on_update_ursa_config_ip_address_update_error]/_serverIpAddress_/$serverIpAddress}"
+    fi
   fi
+}
+
+createUrsaInitialConfig() {
+  if ! touch "$defaultUrsaConfigPath"; then
+    return 1
+  fi
+
+  echo "[server_config]" >> "$defaultUrsaConfigPath"
+  echo "addresses = [\"/ip4/$serverIpAddress/tcp/80\"]" >> "$defaultUrsaConfigPath"
 }
 
 (

--- a/locales/ch
+++ b/locales/ch
@@ -174,3 +174,4 @@ ch["verify_user_has_domain_uh_oh_provide_valid_ip"]="呃哦！请提供有效的
 ch["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="向我们提供您安装节点的机器的 IP 地址。我们注意到这台机器的公共 IP 地址是_detectedIpAddress_（我们将使用它作为默认值）"
 ch["show_docker_stack_log_stack_logs_seems_a_lot"]="好像很多？我们的文档站点提供了所有命令和更多命令！"
 ch["on_latest_preference_mind_ursa_time_build_long"]="好的！请记住，根据您的机器，Ursa 映像可能需要一些时间来构建"
+ch["on_update_ursa_config_ip_address_update_error"]="哎呀！小问题，无法使用服务器 ip _serverIpAddress_ 更新 Ursa 配置"

--- a/locales/de
+++ b/locales/de
@@ -174,3 +174,4 @@ de["verify_user_has_domain_uh_oh_provide_valid_ip"]="Oh oh! Geben Sie bitte eine
 de["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Geben Sie uns die IP-Adresse des Computers an, auf dem Sie den Knoten installieren. Wir haben festgestellt, dass die öffentliche IP-Adresse dieser Maschine _detectedIpAddress_ ist (wir verwenden sie als Standard)"
 de["show_docker_stack_log_stack_logs_seems_a_lot"]="Scheint viel? Alle Befehle und vieles mehr sind auf unserer Dokumentationsseite verfügbar!"
 de["on_latest_preference_mind_ursa_time_build_long"]="OK! Denken Sie daran, dass das Erstellen des Ursa-Image je nach Computer einige Zeit in Anspruch nehmen kann"
+de["on_update_ursa_config_ip_address_update_error"]="Hoppla! Kleineres Problem, die Ursa-Konfiguration konnte nicht mit der Server-IP _serverIpAddress_ aktualisiert werden"

--- a/locales/en
+++ b/locales/en
@@ -174,3 +174,4 @@ en["on_latest_preference_directory_not_empty"]="The directory _selectedUrsaPath_
 en["on_latest_preference_if_stuck_clear_location_1_of_2"]="If you are stuck on this, clear the desired location before retrying"
 en["on_latest_preference_if_stuck_clear_location_2_of_2"]="e.g., if you chose to install in the default _defaultUrsaPath_ clear it, as the assisted installer does not do deletes."
 en["on_latest_preference_success_install_completed"]="The installation process has completed!"
+en["on_update_ursa_config_ip_address_update_error"]="Oops! Minor issue, failed to update the Ursa config with the server ip _serverIpAddress_"

--- a/locales/es
+++ b/locales/es
@@ -174,3 +174,4 @@ es["verify_user_has_domain_uh_oh_provide_valid_ip"]="¡UH oh! Proporcione una di
 es["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Proporciónenos la dirección IP de la máquina donde está instalando el Nodo. Hemos notado que la dirección IP pública de esta máquina es _detectedIpAddress_ (la usaremos como predeterminada)"
 es["show_docker_stack_log_stack_logs_seems_a_lot"]="¿Parece mucho? ¡Todos los comandos y mucho más están disponibles en nuestro sitio de documentación!"
 es["on_latest_preference_mind_ursa_time_build_long"]="¡De acuerdo! Recuerde, la imagen de Ursa puede tardar algún tiempo en construirse dependiendo de su máquina"
+es["on_update_ursa_config_ip_address_update_error"]="¡Ups! Problema menor, no se pudo actualizar la configuración de Ursa con la IP del servidor _serverIpAddress_"

--- a/locales/fr
+++ b/locales/fr
@@ -174,3 +174,4 @@ fr["verify_user_has_domain_uh_oh_provide_valid_ip"]="Oh oh ! Fournissez une adre
 fr["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Fournissez-nous l'adresse IP de la machine sur laquelle vous installez le Node. Nous avons remarqué que l'adresse IP publique de cette machine est _detectedIpAddress_ (nous l'utiliserons par défaut)"
 fr["show_docker_stack_log_stack_logs_seems_a_lot"]="Cela vous semble beaucoup ? Toutes les commandes et bien plus encore sont disponibles sur notre site de documentation !"
 fr["on_latest_preference_mind_ursa_time_build_long"]="D'accord! N'oubliez pas que l'image Ursa peut prendre un certain temps à se créer en fonction de votre machine."
+fr["on_update_ursa_config_ip_address_update_error"]="Oops! Problème mineur, échec de la mise à jour de la configuration Ursa avec l'adresse IP du serveur _serverIpAddress_"

--- a/locales/hi
+++ b/locales/hi
@@ -174,3 +174,4 @@ hi["verify_user_has_domain_uh_oh_provide_valid_ip"]="उह ओह! कृपय
 hi["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="हमें उस मशीन का आईपी पता प्रदान करें जहां आप नोड स्थापित कर रहे हैं। हमने देखा है कि यह मशीन सार्वजनिक आईपी पता _detectedIpAddress_ है (हम इसे डिफ़ॉल्ट के रूप में उपयोग करेंगे)"
 hi["show_docker_stack_log_stack_logs_seems_a_lot"]="बहुत लगता है? हमारे प्रलेखन साइट में सभी आदेश और बहुत कुछ उपलब्ध हैं!"
 hi["on_latest_preference_mind_ursa_time_build_long"]="ठीक है! याद रखें, आपकी मशीन के आधार पर उरसा छवि को बनने में कुछ समय लग सकता है"
+hi["on_update_ursa_config_ip_address_update_error"]="उफ़! मामूली समस्या, उरसा कॉन्फ़िगरेशन को सर्वर आईपी _serverIpAddress_ के साथ अपडेट करने में विफल"

--- a/locales/it
+++ b/locales/it
@@ -174,3 +174,4 @@ it["verify_user_has_domain_uh_oh_provide_valid_ip"]="Uh Oh! Fornisci un indirizz
 it["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Forniscici l'indirizzo IP della macchina su cui stai installando Node. Abbiamo notato che l'indirizzo IP pubblico di questa macchina è _detectedIpAddress_ (lo useremo come predefinito)"
 it["show_docker_stack_log_stack_logs_seems_a_lot"]="Sembra molto? Tutti i comandi e molto altro sono disponibili nel nostro sito di documentazione!"
 it["on_latest_preference_mind_ursa_time_build_long"]="OK! Ricorda, la creazione dell'immagine Ursa potrebbe richiedere del tempo a seconda della tua macchina"
+it["on_update_ursa_config_ip_address_update_error"]="Ops! Problema minore, impossibile aggiornare la configurazione di Ursa con l'ip del server _serverIpAddress_"

--- a/locales/jp
+++ b/locales/jp
@@ -174,3 +174,4 @@ jp["verify_user_has_domain_uh_oh_provide_valid_ip"]="ええとああ！有効な
 jp["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="ノードをインストールするマシンの IP アドレスを提供してください。このマシンのパブリック IP アドレスは _detectedIpAddress_ であることがわかりました (これをデフォルトとして使用します)。"
 jp["show_docker_stack_log_stack_logs_seems_a_lot"]="多いような？すべてのコマンドとその他の機能は、ドキュメント サイトで入手できます。"
 jp["on_latest_preference_mind_ursa_time_build_long"]="Ok！お使いのマシンによっては、Ursa イメージのビルドに時間がかかる場合があります。"
+jp["on_update_ursa_config_ip_address_update_error"]="おっとっと！マイナーな問題、サーバー IP _serverIpAddress_ で Ursa 構成を更新できませんでした"

--- a/locales/ko
+++ b/locales/ko
@@ -174,3 +174,4 @@ ko["verify_user_has_domain_uh_oh_provide_valid_ip"]="어 오! 유효한 IP 주�
 ko["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="노드를 설치하는 시스템의 IP 주소를 제공하십시오. 이 머신 공용 IP 주소가 _detectedIpAddress_임을 확인했습니다(기본값으로 사용함)."
 ko["show_docker_stack_log_stack_logs_seems_a_lot"]="많이 보이는데? 모든 명령과 훨씬 더 많은 기능이 설명서 사이트에서 제공됩니다!"
 ko["on_latest_preference_mind_ursa_time_build_long"]="좋아요! Ursa 이미지는 컴퓨터에 따라 빌드하는 데 시간이 걸릴 수 있습니다."
+ko["on_update_ursa_config_ip_address_update_error"]="이런! 사소한 문제, 서버 IP _serverIpAddress_로 Ursa 구성을 업데이트하지 못했습니다."

--- a/locales/pt
+++ b/locales/pt
@@ -174,3 +174,4 @@ pt["verify_user_has_domain_uh_oh_provide_valid_ip"]="Ué! Forneça um endereço 
 pt["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Forneça-nos o endereço IP da máquina onde você está instalando o Node. Percebemos que o endereço IP público desta máquina é _detectedIpAddress_ (vamos usá-lo como padrão)"
 pt["show_docker_stack_log_stack_logs_seems_a_lot"]="Parece muito? Todos os comandos e muito mais estão disponíveis em nosso site de documentação!"
 pt["on_latest_preference_mind_ursa_time_build_long"]="OK! Lembre-se de que a imagem da Ursa pode levar algum tempo para ser criada, dependendo da sua máquina"
+pt["on_update_ursa_config_ip_address_update_error"]="Ops! Problema menor, falha ao atualizar a configuração do Ursa com o ip do servidor _serverIpAddress_"

--- a/locales/ru
+++ b/locales/ru
@@ -174,3 +174,4 @@ ru["verify_user_has_domain_uh_oh_provide_valid_ip"]="О, о! Укажите де
 ru["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Предоставьте нам IP-адрес машины, на которой вы устанавливаете Node. Мы заметили, что общедоступный IP-адрес этой машины — _detectedIpAddress_ (мы будем использовать его по умолчанию)."
 ru["show_docker_stack_log_stack_logs_seems_a_lot"]="Кажется много? Все команды и многое другое доступны на нашем сайте документации!"
 ru["on_latest_preference_mind_ursa_time_build_long"]="Хорошо! Помните, что создание образа Ursa может занять некоторое время в зависимости от вашей машины."
+ru["on_update_ursa_config_ip_address_update_error"]="Ой! Незначительная проблема, не удалось обновить конфигурацию Ursa с IP-адресом сервера _serverIpAddress_"

--- a/locales/vi
+++ b/locales/vi
@@ -174,3 +174,4 @@ vi["verify_user_has_domain_uh_oh_provide_valid_ip"]="Ồ ồ! Vui lòng cung c�
 vi["verify_user_has_domain_provide_ip_of_machine_1_of_3"]="Cung cấp cho chúng tôi địa chỉ IP của máy mà bạn đang cài đặt Node. Chúng tôi nhận thấy rằng địa chỉ IP công khai của máy này là _detectedIpAddress_ (chúng tôi sẽ sử dụng địa chỉ này làm mặc định)"
 vi["show_docker_stack_log_stack_logs_seems_a_lot"]="Có vẻ nhiều? Tất cả các lệnh và nhiều hơn nữa đều có sẵn trong trang tài liệu của chúng tôi!"
 vi["on_latest_preference_mind_ursa_time_build_long"]="Được rồi! Hãy nhớ rằng, hình ảnh Ursa có thể mất một chút thời gian để tạo tùy thuộc vào máy của bạn"
+vi["on_update_ursa_config_ip_address_update_error"]="Ối! Sự cố nhỏ, không thể cập nhật cấu hình Ursa với ip máy chủ _serverIpAddress_"


### PR DESCRIPTION
# Why?

Set the server ip address in the ~/.ursa/config.toml for the indexer

# How?

- Persist user server IP address
- Computes config.toml
- Provides translation for errors

# Demo?

```toml
[network_config]
mdns = false
relay_server = true
autonat = true
relay_client = true
bootstrapper = false
swarm_addrs = ["/ip4/0.0.0.0/tcp/6009", "/ip4/0.0.0.0/udp/4890/quic-v1"]
bootstrap_nodes = ["/ip4/159.223.211.234/tcp/6009/p2p/12D3KooWDji7xMLia6GAsyr4oiEFD2dd3zSryqNhfxU3Grzs1r9p", "/ip4/146.190.232.131/tcp/6009/p2p/12D3KooWGw8vCj9XayJDMXUiox6pCUFm7oVuWkDJeE2H9SDQVEcM"]
database_path = "~/.ursa/data/ursa_db"
identity = "default"
keystore_path = "~/.ursa/keystore"
tracker = "https://tracker.ursa.earth/register"
kad_replication_factor = 8
kad_walk_interval = 300

[provider_config]
indexer_url = "https://dev.cid.contact"
database_path = "~/.ursa/data/index_provider_db"

[server_config]
addresses = ["/ip4/138.68.161.79/tcp/80"]
port = 4069
addr = "0.0.0.0"

[server_config.origin]
ipfs_gateway = "ipfs.io"

[consensus_config]
address = "/ip4/0.0.0.0/udp/8000"
rpc_domain = "0.0.0.0:8003"
keypair = "~/.ursa/keystore/consensus/primary.key"
network_keypair = "~/.ursa/keystore/consensus/network.key"
store_path = "~/.ursa/data/narwhal_store"
genesis_committee = "~/.ursa/genesis_committee.json"

[consensus_config.parameters]
header_num_of_batches_threshold = 32
max_header_num_of_batches = 1000
max_header_delay = "1000ms"
min_header_delay = "1000ms"
gc_depth = 50
sync_retry_delay = "5000ms"
sync_retry_nodes = 3
batch_size = 500000
max_batch_delay = "1000ms"
max_concurrent_requests = 500000

[consensus_config.parameters.block_synchronizer]
range_synchronize_timeout = "30000ms"
certificates_synchronize_timeout = "30000ms"
payload_synchronize_timeout = "30000ms"
payload_availability_timeout = "30000ms"
handler_certificate_deliver_timeout = "30000ms"

[consensus_config.parameters.consensus_api_grpc]
socket_addr = "/ip4/127.0.0.1/tcp/37661/http"
get_collections_timeout = "5000ms"
remove_collections_timeout = "5000ms"

[consensus_config.parameters.prometheus_metrics]
socket_addr = "/ip4/127.0.0.1/tcp/42857/http"

[consensus_config.parameters.network_admin_server]
primary_network_admin_server_port = 35813
worker_network_admin_server_base_port = 33621

[consensus_config.parameters.anemo]

[[consensus_config.worker]]
address = "/ip4/0.0.0.0/udp/8101/http"
transaction = "/ip4/0.0.0.0/tcp/8102/http"
keypair = "~/.ursa/keystore/consensus/worker-01.key"

[application_config]
domain = "0.0.0.0:8004"
```